### PR TITLE
IO objects and logging

### DIFF
--- a/newlinejson/__init__.py
+++ b/newlinejson/__init__.py
@@ -24,7 +24,7 @@ Example:
 """
 
 
-from newlinejson.core import dump, dumps, load, loads, NLJStream, open
+from newlinejson.core import dump, dumps, load, loads, NLJStream, open, NLJReader, NLJWriter
 
 
 __version__ = '0.4'

--- a/newlinejson/__init__.py
+++ b/newlinejson/__init__.py
@@ -24,6 +24,10 @@ Example:
 """
 
 
+import logging
+
+logger = logging.getLogger('newlinejson')
+
 from newlinejson.core import dump, dumps, load, loads, NLJStream, open, NLJReader, NLJWriter
 
 

--- a/newlinejson/core.py
+++ b/newlinejson/core.py
@@ -352,9 +352,12 @@ def dumps(collection, **json_args):
     str
     """
 
-    with StringIO() as f:
+    f = StringIO()  # No __exit__ in older Python
+    try:
         with NLJWriter(f, 'w', **json_args) as dst:
             for item in collection:
                 dst.write(item)
             f.seek(0)
             return f.read()
+    finally:
+        f.close()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -54,20 +54,6 @@ def test_stream_invalid_mode(dicts_path):
             pass
 
 
-def test_negative_skiplines(dicts_path):
-    with pytest.raises(ValueError):
-        nlj.open(dicts_path, skip_lines=-1)
-
-
-def test_skiplines(dicts_path, compare_iter):
-    sl = 2
-    with open(dicts_path) as f:
-        with nlj.open(dicts_path, skip_lines=sl) as actual:
-            for i in range(sl):
-                next(f)
-            compare_iter(nlj.NLJStream(f), actual)
-
-
 def test_attributes(dicts_path):
     with nlj.open(dicts_path) as src:
         assert src.num_failures is 0
@@ -87,25 +73,25 @@ def test_open_no_with_statement(dicts_path):
 def test_io_clash(dicts_path):
 
     # Trying to read from a stream that is opened in write mode
-    with pytest.raises(OSError):
+    with pytest.raises(TypeError):
         with nlj.open(tempfile.NamedTemporaryFile(mode='w'), 'w') as src:
             next(src)
 
     # Trying to read from a closed stream
     with nlj.open(dicts_path) as src:
         pass
-    with pytest.raises(OSError):
+    with pytest.raises(ValueError):
         next(src)
 
     # Trying to write to a stream opened in read mode
     with nlj.open(tempfile.NamedTemporaryFile(mode='w')) as dst:
-        with pytest.raises(OSError):
+        with pytest.raises(AttributeError):
             dst.write([])
 
     # Trying to write to a closed stream
     with nlj.open(tempfile.NamedTemporaryFile(mode='w'), 'w') as dst:
         pass
-    with pytest.raises(OSError):
+    with pytest.raises(ValueError):
         dst.write([])
 
 
@@ -200,3 +186,13 @@ def test_dump(dicts_path, tmpdir):
     with nlj.open(dicts_path) as src:
         with open(outfile, 'w') as f:
             nlj.dump(src, f)
+
+
+def test_open_bad_mode(dicts_path):
+    # These trigger errors in slightly different but very related lines
+    with pytest.raises(ValueError):
+        with nlj.open(dicts_path, 'bad-mode') as src:
+            pass
+    with pytest.raises(ValueError):
+        with nlj.open(dicts_path, 'rb') as src:
+            pass


### PR DESCRIPTION
Closes #40 (through some local experimentation)
Closes #42

Split `NLJStream()` into `NLJReader()` and `NLJWriter()` for a performance boost.  Prior to splitting a check was made to ensure that the file was open in the correct I/O mode at every read and write.  Now we let that check happen in the underlying file-like object and let the lack of certain methods on certain objects ensure that we don't try to write to a read stream and vice versa.
